### PR TITLE
Update wgrep.c

### DIFF
--- a/wgrep.c
+++ b/wgrep.c
@@ -34,7 +34,7 @@ void grep(wregex_t *r, FILE *infile, FILE *outfile, int flags) {
 
     /* Allocate enough memory for all the submatches in the wregex_t */
     if(r->n_subm > 0) {
-	    subm = calloc(sizeof *subm, r->n_subm);
+	    subm = (wregmatch_t **)calloc(sizeof *subm, r->n_subm);
 	    if(!subm) {
 	        fprintf(stderr, "Error: out of memory");
 	        wrx_free(r);


### PR DESCRIPTION
A minor oversight by Werner, who is a great programmer. This was his most recent repo, from 2017. I've been using it for a while, and it occured to me, his "wgrep" example had a minor bug in it that may have disheartened observers, assuming it didn't work. This library does work, I have it in several of my programs.

In "wgrep.c", where we look for an example of invoking the wregexp libraray, he made the smallest error, then disappeared. In "wgrep.c", line 37, it should say:

subm = (wregmatch_t **)calloc(sizeof *subm, r->n_subm);

Werner actually in his haste forgot the static cast to (wregmatch_t **), which meant automatically an access violation because the "match structure" was technically unstructured (NULL).

This is almost the only 3rd-party library I've ever adopted as one of my personal tools. Werner seems to have gone, and "wgrep.c" was a demo of the library, but would crash because of that smallest oversight.

Lee.